### PR TITLE
Substituindo signal de verificação por método mais otimizado 

### DIFF
--- a/votes/models.py
+++ b/votes/models.py
@@ -3,10 +3,43 @@ import uuid
 from django.db import models
 from stdimage.models import StdImageField
 
+import datetime
+import pytz
+
 def get_file_path(_instance, filename):
     ext = filename.split('.')[-1]
     filename = f'{uuid.uuid4()}.{ext}'
     return filename
+
+class CamaraManager(models.Manager):
+    """
+        Manager criado para verificação de validade de instâncias
+        cada vez que uma query é feita.
+        Deve ser aplicado com os objetos de CamaraVoto.
+    """
+
+    def get_queryset(self):
+        """
+            Método sobreposto para, antes de retornar a lista solicitada,
+            atualizar a validade dos objetos de CamaraVoto
+        """
+        objetos = super().get_queryset()
+
+        for objeto in objetos:
+            objeto.atualizar_validade()
+
+        return objetos
+
+    def get_querybypk(self, pk):
+        """
+            Método criado para, ao solicitar um query por pk, atualizar a validade.
+            dos objetos de CamaraVoto.
+        """
+        objeto = self.get(pk=pk)
+        objeto.atualizar_validade()
+
+        return objeto
+
 
 class Base(models.Model):
 
@@ -19,6 +52,8 @@ class Base(models.Model):
 
 class CamaraVoto(Base):
 
+    objects = CamaraManager()
+
     nome = models.CharField('Nome da Camara de Votos', max_length=30, unique=True)
     inicio = models.DateTimeField('Inicio')
     termino = models.DateTimeField('Termino')
@@ -26,6 +61,16 @@ class CamaraVoto(Base):
 
     def __str__(self):
         return self.nome
+
+    def atualizar_validade(self):
+
+        termino = self.termino
+        agora = pytz.timezone("UTC").localize(datetime.datetime.now())
+
+        if termino < agora:
+            self.ativo = False
+            self.save()
+
 
 class Objeto(models.Model):
 
@@ -35,6 +80,4 @@ class Objeto(models.Model):
     imagem = StdImageField('Imagem', default="/static/img/blank-profile.png", upload_to=get_file_path,
                     variations={'thumb': {'width': 400, 'height': 400, 'crop': True}})
     votos = models.IntegerField('Votos', default=0)
-
-
 

--- a/votes/signals.py
+++ b/votes/signals.py
@@ -2,30 +2,7 @@ from .models import CamaraVoto
 
 from django.template.defaultfilters import slugify
 from django.db.models.signals import pre_save
-from django.core.signals import request_started
 from django.dispatch import receiver
-
-import datetime
-import pytz
-
-@receiver(request_started, dispatch_uid='att_camaras')
-def atualizar_camaras(sender, environ, **kwargs):
-    """
-    - Serve para verificar e atualizar, a cada request, se o tempo de uma camara já se
-    encerrou, mudando seu estado de ativo (True) pra não ativo (False).
-    - Explicando sobre timezone em python e em como lidar com naive datetime e aware datetime:
-        - https://howchoo.com/g/ywi5m2vkodk/working-with-datetime-objects-and-timezones-in-python
-    """
-
-    camaras = CamaraVoto.objects.all()
-    for camara in camaras:
-
-        termino = camara.termino
-        agora = pytz.timezone("UTC").localize(datetime.datetime.now())
-
-        if termino < agora:
-            camara.ativo = False
-            camara.save()
 
 @receiver(pre_save, sender=CamaraVoto, dispatch_uid='slug_camara')
 def camara_pre_save(sender, instance, **kwargs):


### PR DESCRIPTION
close: [#3](https://github.com/svhenrique/projext-web-project/issues/3)

- Signal que verifica a cada request a validade dos objetos de CamaraVoto foi removido.
- Método utilizando Manager que verifica a cada query a validade dos objetos foi adicionado.
- Como, no novo método, a verificação ocorre a cada query, verificações desnecessárias são evitadas.
- Novo método otimiza a verificação e a deixa mais rápida. 
